### PR TITLE
Improve mpas plot py

### DIFF
--- a/post_proc/py/plot_scalar_on_native_grid/mpas_plot.py
+++ b/post_proc/py/plot_scalar_on_native_grid/mpas_plot.py
@@ -162,9 +162,10 @@ def colorvalue(val, da, vmin=None, vmax=None, cmap='Spectral'):
         
     return cm(norm_val)
 
-def plot_cells_mpas(da, ds, ax, **plot_kwargs):
+def plot_cells_mpas(da, ds, ax, plotEdge=True, **plot_kwargs):
     # da: specific xarray to be plotted (time/level filtered)
     # ds: general xarray with grid structure, require for grid propreties
+    # plotEdge: wether the cell edge should be visible or not. For high-resolution grids figure looks better if plotEdge=False
 
     # ax = start_cartopy_map_axis()
     print("Generating grid plot and plotting variable. This may take a while...")
@@ -195,12 +196,19 @@ def plot_cells_mpas(da, ds, ax, **plot_kwargs):
         # Shift +360 deg the negative longitude
         if max(lons) > 170 and min(lons) < -170 :
             lons = xr.where(lons >= 170.0, lons - 360.0, lons)
-            
-        ax.fill(lons, lats, edgecolor='grey', linewidth=0.1, facecolor=color)
+
+        if plotEdge:
+            edgecolor = 'grey'
+            lw = 0.1
+        else:
+            edgecolor = None   
+            lw = None
+
+        ax.fill(lons, lats, edgecolor=edgecolor, linewidth=lw, facecolor=color)
         
     return
 
-def plot_dual_mpas(da, ds, ax, **plot_kwargs):
+def plot_dual_mpas(da, ds, ax, plotEdge=True, **plot_kwargs):
 
     #Loop over all Voronoi cell vertices - which are triangle circumcentres
     print("Generating grid plot and plotting variable. This may take a while...")
@@ -231,8 +239,15 @@ def plot_dual_mpas(da, ds, ax, **plot_kwargs):
         if max(lons) > 170 and min(lons) < -170 :
             lons = xr.where(lons >= 170.0, lons - 360.0, lons)
 
+        if plotEdge:
+            edgecolor = 'grey'
+            lw = 0.1
+        else:
+            edgecolor = None   
+            lw = None
+
         # Plot polygons and variable
-        ax.fill(lons, lats, edgecolor='grey', linewidth=0.1, facecolor=color)
+        ax.fill(lons, lats, edgecolor=edgecolor, linewidth=lw, facecolor=color)
     
     return
         


### PR DESCRIPTION
I added a two new options to the mpas_plot.py ploting script a few improvements:

1) New command-line option `-g [y|n]`, `--grid [y|n]` to tell wether we should draw the cells edges or not. 
For high-resolution grids it is better NOT to draw the grid, just fill the polygon color. The default is the previous behaviour, to draw the grid.

2) New command-line option `c [y|n]`, `--clip [y|n]` to tell wether we should clip large value out. When there are few large values they range of the colormap too big and we lose capturing some features of the field.
If `--clip yes` is used  we change the maximum value of the field `x`, `max_x`  to `new_max_x = min(max_x, mean(x) + 4*std(x))`. The default is the previous behaviour, not to clip the max values.

Improvements:

1) For a 50km resolution mesh, before this PR it was taking 3h to plot the vorticity field. With this PR it takes 30min.
The issue was the maximum and minmum values of the field were been searched for over and over again at each cell iteration. I just moved that search out of the loop.

2) I construct the colormap now in a way that, when the field has positive and negative values, the value zero is always in the middle of the colormap. For the default colormap it means the color yellow is always zero. It makes it easier to compare the same field across time.