### PR TITLE
Gtm/mpas plot external mesh properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ stream_list.*
 benchmarks/__pycache__/*
 grids/utilities/jigsaw/__pycache__/*
 post_proc/py/geometry_lat_lon_2d_plot/__pycache__/*
+post_proc/py/__pycache__/
 
 src/core_*/inc
 .DS_Store
@@ -110,3 +111,4 @@ local_software/gccsources/
 local_software/people/*
 met_data/ERA5/scripts/APIs/*
 .vscode
+grids/utilities/convert_nc_grid_to_xyz/convert_grid_to_xyz

--- a/MPAS-BR-contributions-GTM.md
+++ b/MPAS-BR-contributions-GTM.md
@@ -1,0 +1,11 @@
+
+Modifications by Guilherme Torres Mendonça
+===========================================
+
+   Date: Mar 2024
+
+   Features:
+   - Updated plotting script to consider case where input file does not contain grid properties
+
+   All relevant modifications were marked with GTM text and a comment
+

--- a/post_proc/py/plot_scalar_on_native_grid/mpas_plot.py
+++ b/post_proc/py/plot_scalar_on_native_grid/mpas_plot.py
@@ -7,6 +7,7 @@ Originally From: ??
 Edited: Danilo  <danilo.oceano@gmail.com>  in 2023
 Last edited: Nov 2023 by P. Peixoto (ppeixoto@usp.br)
 Last edited: Nov 2023 by F.A.V.B. Alves (fbalves@usp.br)
+Last edited: Mar 2024 by G. Torres Mendonça (guilherme.torresmendonca@ime.usp.br)
 
 """
 
@@ -337,7 +338,8 @@ def close_plot(fig=None, size_fig=None, pdf=None, outfile=None,
     plt.close()
 
 
-def plot_mpas_darray(ds, vname, time=None, level=None, ax=None, outfile=None, title=None, plotEdge=True, clip=False, **kwargs):
+def plot_mpas_darray(ds, vname, time=None, level=None, ax=None, outfile=None, 
+                     title=None, plotEdge=True, clip=False, gridfile=None, **kwargs):
     
     ## plot_mpas_darray
     da = ds[vname]
@@ -397,6 +399,7 @@ def view_mpas_mesh(mpas_grid_file, outfile=None,
                             level=None,
                             plotEdge=True,
                             clip=False,
+                            gridfile=None,
                             **kwargs):
     
     ds = open_mpas_file(mpas_grid_file)
@@ -419,7 +422,9 @@ def view_mpas_mesh(mpas_grid_file, outfile=None,
     if level is not None:
         tit = tit + " Level="+str(level)
                 
-    plot_mpas_darray(ds, vname, time=time, level=level, ax=ax, title=tit, plotEdge=plotEdge,clip=clip)
+    plot_mpas_darray(ds, vname, time=time, level=level, ax=ax, 
+                     title=tit, plotEdge=plotEdge, clip=clip,
+                     gridfile=gridfile)
     
     close_plot(outfile=outfile)
         
@@ -472,6 +477,10 @@ if __name__ == "__main__":
         help="Clip values grater than (expected_val + 4*std): yes or no",
     )
 
+    parser.add_argument(
+        "-gf", "--gridfile", type=str, default=None,
+        help="Name of a MPAS data file that contains grid properties (.nc)",
+    )
 
     args = parser.parse_args()
     
@@ -489,4 +498,6 @@ if __name__ == "__main__":
     else:
         clip=False
 
-    view_mpas_mesh(args.infile, outfile=args.outfile, time=args.time, level=args.level, vname=args.var, plotEdge=plotEdge,clip=clip)
+    view_mpas_mesh(args.infile, outfile=args.outfile, time=args.time, 
+                   level=args.level, vname=args.var, plotEdge=plotEdge,
+                   clip=clip, gridfile=args.gridfile)

--- a/post_proc/py/plot_scalar_on_native_grid/mpas_plot.py
+++ b/post_proc/py/plot_scalar_on_native_grid/mpas_plot.py
@@ -211,8 +211,9 @@ def plot_cells_mpas(da, ds, ax, plotEdge=True, gridfile=None, **plot_kwargs):
     # plotEdge: wether the cell edge should be visible or not. For high-resolution grids figure looks better if plotEdge=False
 
     # Check if grid properties needed for plotting are in ds
-    grid_properties = 'verticesOnCell nEdges latitudeVertex longitudeVertex'
-    if grid_properties in ds.keys():
+    grid_properties = ['verticesOnCell', 'nEdgesOnCell']
+
+    if set(grid_properties).issubset(set(ds.keys())):
         print (f"{grid_properties} found in dataset.")
         ds_grid = ds
     else:
@@ -221,7 +222,7 @@ def plot_cells_mpas(da, ds, ax, plotEdge=True, gridfile=None, **plot_kwargs):
         try:
             # Open additional grid file
             ds_grid = open_mpas_file(gridfile)
-            if grid_properties in ds_grid.keys():
+            if set(grid_properties).issubset(set(ds_grid.keys())):
                 print (f"{grid_properties} found in additional grid file.")
         except:
             raise RuntimeError(f"Recovery of {grid_properties} failed.")

--- a/post_proc/py/plot_scalar_on_native_grid/mpas_plot.py
+++ b/post_proc/py/plot_scalar_on_native_grid/mpas_plot.py
@@ -210,7 +210,7 @@ def plot_cells_mpas(da, ds, ax, plotEdge=True, gridfile=None, **plot_kwargs):
     # ds: general xarray with grid structure, require for grid propreties
     # plotEdge: wether the cell edge should be visible or not. For high-resolution grids figure looks better if plotEdge=False
 
-    # Check if grid properties needed for plotting are in ds
+    # GTM: check if grid properties needed for plotting are in ds
     grid_properties = ['verticesOnCell', 'nEdgesOnCell']
 
     if set(grid_properties).issubset(set(ds.keys())):
@@ -233,6 +233,7 @@ def plot_cells_mpas(da, ds, ax, plotEdge=True, gridfile=None, **plot_kwargs):
 
         value = da.sel(nCells=cell)
 
+        # GTM: now grid properties are taken from ds_grid, defined above
         vertices = ds_grid['verticesOnCell'].sel(nCells=cell).values
         num_sides = int(ds_grid['nEdgesOnCell'].sel(nCells=cell))
     
@@ -495,6 +496,7 @@ if __name__ == "__main__":
         help="Clip values grater than (expected_val + 4*std): yes or no",
     )
 
+    # GTM: option to supply additional file containing grid properties of infile
     parser.add_argument(
         "-gf", "--gridfile", type=str, default=None,
         help="Name of additional file that contains grid properties of MPAS"

--- a/post_proc/py/plot_scalar_on_native_grid/mpas_plot.py
+++ b/post_proc/py/plot_scalar_on_native_grid/mpas_plot.py
@@ -20,9 +20,6 @@ import numpy as np
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import cartopy.crs as ccrs
-import cartopy.feature as cfeature
-from geopy.distance import distance
-import pandas as pd
 
 import argparse
 


### PR DESCRIPTION
Updated mpas_plot.py to account for case where infile does not contain the grid properties needed for plotting. In that case, this update offers the option to supply an additional file that does contain these properties.

I added a GTM and a comment on all relevant modifications. However, since in the pull request the modifications to the previous script are already highlighted, I did not comment out old code but simply deleted it -- let me know if there is reason for doing otherwise.